### PR TITLE
improve travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: php
-php:
-  - 5.6
-  - 7.1
-  - 7.2
-  - 7.4
+matrix:
+  include:
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+    - php: nightly
+  allow_failures:
+    - php: nightly
+  fast_finish: true
 branches:
   only:
     master


### PR DESCRIPTION
add php nightly version (php 8 currently) to travis with allowing to fail

add php 7.0 version